### PR TITLE
Temporary fix to get content placed correctly on load

### DIFF
--- a/js/styleController.js
+++ b/js/styleController.js
@@ -7,6 +7,6 @@ $(window).resize(function() {
     PlaceContent();
 });
 
-$(document).ready(function() {
+$(window).load(function() {
     PlaceContent();
 });


### PR DESCRIPTION
Window.load will need to be replaced if heavier items like images are
added to the site down the road